### PR TITLE
Updates to use Vertica 8.1 on centos7 base

### DIFF
--- a/Dockerfile.centos.7_8.1
+++ b/Dockerfile.centos.7_8.1
@@ -15,7 +15,7 @@ RUN yum -q -y update \
  && /usr/sbin/groupadd -r verticadba \
  && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba dbadmin \
  && /usr/local/bin/gosu dbadmin mkdir /tmp/.python-eggs \
- && yum install -y which mcelog gdb sysstat openssh-server openssh-clients \
+ && yum install -y which mcelog gdb sysstat openssh-server openssh-clients iproute \
  && yum localinstall -q -y /tmp/${VERTICA_PACKAGE}
 
 RUN /opt/vertica/sbin/install_vertica --license CE --accept-eula --hosts 127.0.0.1 --dba-user-password-disabled --failure-threshold NONE --no-system-configuration \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+STOP_LOOP="false"
+
 # Vertica should be shut down properly
 function shut_down() {
   echo "Shutting Down"
@@ -8,6 +10,8 @@ function shut_down() {
   echo 'Saving configuration'
   mkdir -p ${VERTICADATA}/config
   /bin/cp /opt/vertica/config/admintools.conf ${VERTICADATA}/config/admintools.conf
+  echo 'Stopping loop'
+  STOP_LOOP="true"
 }
 
 function vertica_proper_shutdown() {
@@ -24,7 +28,7 @@ function fix_filesystem_permissions() {
   chown dbadmin:verticadba /opt/vertica/config/admintools.conf
 }
 
-trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT EXIT
+trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT
 
 
 echo 'Starting up'
@@ -34,8 +38,10 @@ if [ -z "$(ls -A "${VERTICADATA}")" ]; then
   echo 'Creating database'
   su - dbadmin -c "/opt/vertica/bin/admintools -t create_db --skip-fs-checks -s localhost -d docker -c ${VERTICADATA}/catalog -D ${VERTICADATA}/data"
 else
-  echo 'Restoring configuration'
-  cp ${VERTICADATA}/config/admintools.conf /opt/vertica/config/admintools.conf
+  if [ -f ${VERTICADATA}/config/admintools.conf ]; then
+    echo 'Restoring configuration'
+    cp ${VERTICADATA}/config/admintools.conf /opt/vertica/config/admintools.conf
+  fi
   echo 'Fixing filesystem permissions'
   fix_filesystem_permissions
   echo 'Starting Database'
@@ -44,6 +50,6 @@ fi
 
 echo "Vertica is now running"
 
-while true; do
+while [ "${STOP_LOOP}" == "false" ]; do
   sleep 1
 done


### PR DESCRIPTION
I tried to build image with Vertica 8.1.0 from your repository. Changes to make usage of Vertica without volume possible:
- missing iproute package
- first usage of container without volume has no ${VERTICADATA}/config/admintools.conf

Changes to make stop of container easier:
- add flag to stop infinite loop