### PR TITLE
Closes issue #10: Fixing soft limits by allowing Vertica install to configure /etc/secu…

### DIFF
--- a/Dockerfile.ubuntu.16.04_9.x
+++ b/Dockerfile.ubuntu.16.04_9.x
@@ -22,11 +22,13 @@ RUN /usr/bin/apt-get update -yqq \
  && /usr/sbin/dpkg-reconfigure locales \
  && /usr/bin/apt-get install --no-install-recommends -yqq openssh-server openssh-client mcelog sysstat dialog \
                              libexpat1 iproute2 \
+                             ntp \
  && /usr/bin/dpkg -i /tmp/${VERTICA_PACKAGE} \
  && rm /tmp/${VERTICA_PACKAGE}
 
 RUN /opt/vertica/sbin/install_vertica --license CE --accept-eula --hosts 127.0.0.1 \
-                                      --dba-user-password-disabled --failure-threshold NONE --no-system-configuration
+                                      --dba-user-password-disabled --failure-threshold NONE 
+                                      #--no-system-configuration
 
 RUN /usr/bin/apt-get remove --purge -y curl ca-certificates libpython2.7 \
  && /bin/bash /tmp/debian_cleaner.sh


### PR DESCRIPTION
…rity/limits.conf and adding ntp service to avoid ERROR:  Database did not start cleanly on initiator node!

Original Dockerfile results in:
```shell
$ docker run jbfavre/vertica:9.2.0-6_ubuntu-16.04
Unable to find image 'jbfavre/vertica:9.2.0-6_ubuntu-16.04' locally
9.2.0-6_ubuntu-16.04: Pulling from jbfavre/vertica
34667c7e4631: Pull complete
d18d76a881a4: Pull complete
119c7358fbfc: Pull complete
2aaf13f3eff0: Pull complete
e9238a8d18ef: Pull complete
dc0aa2ef9b48: Pull complete
7fb35d29817c: Pull complete
35bf5c31df6b: Pull complete
34856d280183: Pull complete
9be870aa3165: Pull complete
Digest: sha256:8cfd120f1a70c34c51ef5ef6c6963897654d56460b92eae7bf63cb89a346b673
Status: Downloaded newer image for jbfavre/vertica:9.2.0-6_ubuntu-16.04
Starting up
Fixing filesystem permissions
Creating database
Info: no password specified, using none
Database with 1 or 2 nodes cannot be k-safe and it may lose data if it crashes
Distributing changes to cluster.
        Creating database docker
        Starting bootstrap node v_docker_node0001 (127.0.0.1)
Error: Failed to load the startup information from the bootstrap node.
Hint: Are your resource limits for new processes correct?
```

Allowing Vertica install to configure soft limits startup proceeds to the following error
```shell
$ docker run akodd/vertica:test
Starting up
Fixing filesystem permissions
Creating database
Info: no password specified, using none
Database with 1 or 2 nodes cannot be k-safe and it may lose data if it crashes
Distributing changes to cluster.
        Creating database docker
        Starting bootstrap node v_docker_node0001 (127.0.0.1)
        Starting nodes:
                v_docker_node0001 (127.0.0.1)
        Starting Vertica on all nodes. Please wait, databases with a large catalog may take a while to initialize.
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
ERROR:  Database did not start cleanly on initiator node!
        Stopping all nodes
Could not connect to database (EOF received)vsql: could not connect to server: Connection refused
        Is the server running on host "127.0.0.1" and accepting
        TCP/IP connections on port 5433?

Error: Database did not start cleanly on initiator node!  Stopping all nodes
``` 

Adding ntp service allows Vertica to start:
```shell
$ docker run akodd/vertica:test
Starting up
Fixing filesystem permissions
Creating database
Info: no password specified, using none
Database with 1 or 2 nodes cannot be k-safe and it may lose data if it crashes
Distributing changes to cluster.
        Creating database docker
        Starting bootstrap node v_docker_node0001 (127.0.0.1)
        Starting nodes:
                v_docker_node0001 (127.0.0.1)
        Starting Vertica on all nodes. Please wait, databases with a large catalog may take a while to initialize.
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (DOWN)
        Node Status: v_docker_node0001: (UP)
Automatically installing extension packages
Package: voltagesecure
        Failure: unable to install package voltagesecure
Package: kafka
        Success: package kafka successfully installed
Package: txtindex
        Success: package txtindex successfully installed
Package: logsearch
        Success: package logsearch successfully installed
Package: ParquetExport
        Success: package ParquetExport successfully installed
Package: MachineLearning
        Success: package MachineLearning successfully installed
Package: flextable
        Success: package flextable successfully installed
Package: place
        Success: package place successfully installed
Package: approximate
        Success: package approximate successfully installed
Package: AWS
        Success: package AWS successfully installed
Package: VFunctions
        Success: package VFunctions successfully installed
Database docker created successfully.
```

